### PR TITLE
Use dask-core instead of dask

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install --no-deps -vv .
   entry_points:
     - prefect = prefect.cli:cli
@@ -25,7 +25,7 @@ requirements:
     - click >=7.0,<8.0
     - cloudpickle >=0.6.0,<1.3
     - croniter >=0.3.24,<1.0
-    - dask[bag] >=0.19.3,<3.0
+    - dask-core >=0.19.3,<3.0
     - distributed >=1.26.1,<3.0
     - docker-py >=3.4.1,<5.0
     - marshmallow >=3.0.0b19,<4.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,8 +50,6 @@ test:
     - prefect.tasks.shell
     - prefect.tasks.control_flow
     - prefect.tasks.github
-    - prefect.tasks.templates
-    - prefect.tasks.templates.jinja2
 
 about:
   home: https://github.com/PrefectHQ/prefect


### PR DESCRIPTION
This actually previously used dask[bag], which is pip syntax - I'm surprised this didn't error outright.