### PR TITLE
Align griffe >= 0.20.0, <0.48.0 with upstream requirements-client.txt

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - exceptiongroup >=1.2.1
     - docker-py >=4.0
     - fsspec >=2022.5.0
-    - griffe >=0.20.0
+    - griffe >=0.20.0, <0.48.0
     - httpcore >=0.15.0, <2.0.0
     - httpx >=0.23, !=0.23.2
     - importlib_metadata >=4.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install --no-deps -vv .
   entry_points:
     - prefect = prefect.cli:app


### PR DESCRIPTION
Aligns griffe pins with those specified in requirements-client.txt of [v2.20.2](https://github.com/PrefectHQ/prefect/blob/2.20.2/requirements.txt)

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
