### PR TITLE
Update for websockets=15

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -79,7 +79,9 @@ requirements:
     - ujson >=5.8.0, <6.0.0
     - python-uv >=0.6.0
     - uvicorn >=0.14.0,!=0.29.0
-    - websockets >=10.4, <14.0
+    - websockets >=13.0, <16.0
+
+
 
 test:
   imports:


### PR DESCRIPTION
The websockets version requirements were updated in https://github.com/PrefectHQ/prefect/commit/79cb8b5d9b6358d89089ed2076694c324f8644e8 `prefect==3.2.8`, need to change the pinning of `websockets` here too (currently `prefect` conda can error for `websockets==11` for example)

Closes #382

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
